### PR TITLE
Fix Readme (Download section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Grab the latest dependency through Gradle:
 
 ```Groovy
 dependencies {
-    implementation 'com.pixplicity.easyprefs:library:1.10.0'
+    implementation 'com.pixplicity.easyprefs:EasyPrefs:1.10.0'
 }
 ```
 


### PR DESCRIPTION
After migrating to Maven Central the name was changed